### PR TITLE
Renaming tables of GB fork

### DIFF
--- a/migrations/20210401_000000_create_taxonomies_table.php
+++ b/migrations/20210401_000000_create_taxonomies_table.php
@@ -9,6 +9,10 @@ return [
             $schema->rename('fof_taxonomies', 'flamarkt_taxonomies');
             return;
         }
+        if ($schema->hasTable('gb_taxonomies')) {
+            $schema->rename('gb_taxonomies', 'flamarkt_taxonomies');
+            return;
+        }
 
         $schema->create('flamarkt_taxonomies', function (Blueprint $table) {
             $table->increments('id');

--- a/migrations/20210401_000100_create_terms_table.php
+++ b/migrations/20210401_000100_create_terms_table.php
@@ -9,6 +9,10 @@ return [
             $schema->rename('fof_taxonomy_terms', 'flamarkt_taxonomy_terms');
             return;
         }
+        if ($schema->hasTable('gb_taxonomy_terms')) {
+            $schema->rename('gb_taxonomy_terms', 'flamarkt_taxonomy_terms');
+            return;
+        }
 
         $schema->create('flamarkt_taxonomy_terms', function (Blueprint $table) {
             $table->increments('id');

--- a/migrations/20210401_000200_create_discussion_term_table.php
+++ b/migrations/20210401_000200_create_discussion_term_table.php
@@ -9,6 +9,10 @@ return [
             $schema->rename('fof_discussion_taxonomy_term', 'flamarkt_discussion_taxonomy_term');
             return;
         }
+        if ($schema->hasTable('gb_discussion_taxonomy_term')) {
+            $schema->rename('gb_discussion_taxonomy_term', 'flamarkt_discussion_taxonomy_term');
+            return;
+        }
 
         $schema->create('flamarkt_discussion_taxonomy_term', function (Blueprint $table) {
             $table->unsignedInteger('discussion_id');

--- a/migrations/20210401_000300_create_term_user_table.php
+++ b/migrations/20210401_000300_create_term_user_table.php
@@ -9,6 +9,10 @@ return [
             $schema->rename('fof_taxonomy_term_user', 'flamarkt_taxonomy_term_user');
             return;
         }
+        if ($schema->hasTable('gb_taxonomy_term_user')) {
+            $schema->rename('gb_taxonomy_term_user', 'flamarkt_taxonomy_term_user');
+            return;
+        }
 
         $schema->create('flamarkt_taxonomy_term_user', function (Blueprint $table) {
             $table->unsignedInteger('term_id');


### PR DESCRIPTION
I had to add this to be able to migrate from our internal @glowingblue fork.

Tested locally, migration was successful!