### PR TITLE
Fix error when resource has no taxonomyTerms

### DIFF
--- a/js/src/common/components/ChooseTaxonomyTermsModal.ts
+++ b/js/src/common/components/ChooseTaxonomyTermsModal.ts
@@ -68,7 +68,7 @@ export default class ChooseTaxonomyTermsModal extends Modal<ChooseTaxonomyTermsM
 
         if (this.attrs.selectedTerms) {
             this.attrs.selectedTerms.forEach(this.addTerm.bind(this));
-        } else if (this.attrs.resource) {
+        } else if (this.attrs.resource && this.attrs.resource.taxonomyTerms()) {
             this.attrs.resource.taxonomyTerms().forEach((term: Term) => {
                 if (term.taxonomy().id() === this.attrs.taxonomy.id()) {
                     this.addTerm(term);


### PR DESCRIPTION
I got into a situation where I encountered this error and the app crashed because of it. Adding this small test to the if statement fixes it. 

```
TypeError: this.attrs.resource.taxonomyTerms().forEach is not a function
```